### PR TITLE
Bug fix - Logical not doesn't work with browser conditions

### DIFF
--- a/src/logical/not.ts
+++ b/src/logical/not.ts
@@ -6,12 +6,12 @@
  *
  * @param {!Function} expectedCondition The function to check
  *
- * @returns {!function} An expected condition that returns that returns the negated value.
+ * @returns {!function} An expected condition that returns the negated value.
  */
 
 export function not(expectedCondition: () => Promise<boolean>): () => Promise<boolean> {
-  return async (): Promise<boolean> => {
-    const result = await expectedCondition()
+  return async function (this:WebdriverIO.Browser): Promise<boolean> {
+    const result = await expectedCondition.call(this)
 
     return !result
   }

--- a/tests/logical/logicalWithBrowser.test.ts
+++ b/tests/logical/logicalWithBrowser.test.ts
@@ -1,0 +1,44 @@
+import * as EC from '../../src/index.js'
+
+const usernameSelector = '#username'
+const passwordSelector = '#password'
+const submitButton = 'button[type="submit"]'
+const subHeader = '.subheader'
+const logoutButton = 'a.button[href="/logout"]'
+const welcomeText = 'Welcome to the Secure Area.'
+
+describe('browser and logical not', () => {
+    it('should open login page', async () => {
+        await browser.url('/login')
+        await expect(await EC.urlContains('login').call(browser)).toBe(true)
+    })
+
+    it('should enter credentials', async () => {
+        const username = await $(usernameSelector)
+        const password = await $(passwordSelector)
+
+        await username.setValue('tomsmith')
+        await password.setValue('SuperSecretPassword!')
+
+        await expect(await username.getValue()).toEqual('tomsmith')
+        await expect(await password.getValue()).toEqual('SuperSecretPassword!')
+    })
+
+    it('should wait until the user get redirected from login page', async () => {
+        await $(submitButton).click()
+        await browser.waitUntil(() => EC.not(EC.urlContains('login')).call(browser))
+        await expect(await EC.urlContains('login').call(browser)).toBe(false)
+    })
+
+    it('should verify user has logged in', async () => {
+        await expect(await $(subHeader)).toBeExisting()
+        const subHeaderText = await $(subHeader).getText()
+        await expect(subHeaderText).toContain(welcomeText)
+    })
+
+    it('should wait until the user get redirected to login page', async () => {
+        await $(logoutButton).click()
+        await browser.waitUntil(() => EC.urlContains('login').call(browser))
+        await expect(await EC.urlContains('login').call(browser)).toBe(true)
+    })
+})


### PR DESCRIPTION
Issue:
- Logical `not` doesn't work with browser conditions #175

Changes: 
- updated `not` arrow function to simple `function` 
- Test case added regarding issue

fixes https://github.com/webdriverio/wdio-wait-for/issues/175